### PR TITLE
 [#1] Update Gemini model to gemini-2.5-flash

### DIFF
--- a/autoload/vimgeminitranslate.vim
+++ b/autoload/vimgeminitranslate.vim
@@ -4,7 +4,7 @@ function! vimgeminitranslate#TranslateSelectionToEnglish()
   let l:text = join(getline(l:start_line, l:end_line), "\n")
 
   " Translate using Gemini CLI, filter out logs/warnings
-  let l:translated = system('echo '.shellescape(l:text).' | gemini "Translate the following Japanese text to English:" 2>/dev/null | grep -v "DeprecationWarning" | grep -v "Loaded cached credentials"')
+  let l:translated = system('echo '.shellescape(l:text).' | gemini --model gemini-2.5-flash "Translate the following Japanese text to English:" 2>/dev/null | grep -v "DeprecationWarning" | grep -v "Loaded cached credentials"')
 
   " Replace selected lines with translation
   call setline(l:start_line, split(l:translated, "\n"))


### PR DESCRIPTION
Closes #1

This PR updates the vim-gemini-translate plugin to use the `gemini-2.5-flash` model for translations.
The `--model gemini-2.5-flash` flag has been added to the `gemini` CLI command in `autoload/vimgeminitranslate.vim`.

**Implementation Details:**
- The `system()` call in `autoload/vimgeminitranslate.vim` was modified to include `--model gemini-2.5-flash` in the `gemini` command.

**Notes for Reviewers:**
- This change ensures that the plugin utilizes the specified Gemini model for improved translation performance.
