### PR TITLE
[#8] Fix syntax error in DeepL API call function

### DIFF
--- a/autoload/vimgeminitranslate.vim
+++ b/autoload/vimgeminitranslate.vim
@@ -44,8 +44,7 @@ function! s:TranslateWithDeepL(text)
   \   'curl -s -X POST %s -H "Authorization: DeepL-Auth-Key %s" --data-urlencode %s --data-urlencode "target_lang=EN"',
   \   shellescape(l:endpoint),
   \   l:api_key,
-  \   'text=' . shellescape(a:text)
-  	)
+  \   'text=' . shellescape(a:text))
 
   let l:response = system(l:curl_cmd)
   let l:response_dict = json_decode(l:response)


### PR DESCRIPTION
Closes #8

This PR fixes a syntax error in the `s:TranslateWithDeepL` function in `autoload/vimgeminitranslate.vim`. A stray tab character was causing the `printf` call to fail, which prevented the DeepL API from being called correctly. The fix removes this character, restoring the translation functionality.